### PR TITLE
Change content fields to be of type text

### DIFF
--- a/database/migrations/2019_10_11_105304_create_mailcoach_tables.php
+++ b/database/migrations/2019_10_11_105304_create_mailcoach_tables.php
@@ -26,12 +26,12 @@ class CreateMailcoachTables extends Migration
 
             $table->boolean('requires_confirmation')->default(false);
             $table->string('confirmation_mail_subject')->nullable();
-            $table->string('confirmation_mail_content')->nullable();
+            $table->text('confirmation_mail_content')->nullable();
             $table->string('confirmation_mailable_class')->nullable();
 
             $table->boolean('send_welcome_mail')->nullable();
             $table->string('welcome_mail_subject')->nullable();
-            $table->string('welcome_mail_content')->nullable();
+            $table->text('welcome_mail_content')->nullable();
             $table->string('welcome_mailable_class')->nullable();
 
             $table->string('report_recipients')->nullable();


### PR DESCRIPTION
- the default string length of 255 in MySQL is too small to hold the content of the mails I've been creating.