### PR TITLE
Fix icon alignment in dropdown list

### DIFF
--- a/resources/views/vendor/mailcoach/app/layouts/partials/headerRight.blade.php
+++ b/resources/views/vendor/mailcoach/app/layouts/partials/headerRight.blade.php
@@ -6,21 +6,21 @@
         <li>
             <a href="{{ route('account') }}">
                 <span class="icon-label">
-                    <i class="fas fa-user"></i> Account
+                    <i class="fas fa-fw fa-user"></i> Account
                 </span>
             </a>
         </li>
         <li>
             <a href="{{ route('users') }}">
                 <span class="icon-label">
-                    <i class="fas fa-users"></i> Users
+                    <i class="fas fa-fw fa-users"></i> Users
                 </span>
             </a>
         </li>
         <li>
             <a href="{{ route('mailConfiguration') }}">
                 <span class="icon-label">
-                    <i class="fas fa-server"></i>Mail&nbsp;configuration
+                    <i class="fas fa-fw fa-server"></i>Mail&nbsp;configuration
                 </span>
             </a>
         </li>
@@ -28,7 +28,7 @@
             <form method="post" action="{{ route('logout') }}">
                 <button type="submit">
                     <span class="icon-label">
-                        <i class="fas fa-power-off text-red-500"></i>
+                        <i class="fas fa-fw fa-power-off text-red-500"></i>
                         Log out
                     </span>
                 </button>


### PR DESCRIPTION
Icons in dropdown list are currently not aligning, by using fontawesome's fa-fw helper they all get the same width (1.25em) and causes the icons and labels to line up correctly

Before:
![Schermafbeelding 2020-02-15 om 12 05 21](https://user-images.githubusercontent.com/7728097/74586785-870e6d80-4feb-11ea-921a-a2f62726e3b7.png)

After:
![Schermafbeelding 2020-02-15 om 12 05 30](https://user-images.githubusercontent.com/7728097/74586788-883f9a80-4feb-11ea-9fbd-75ce334cb65c.png)
