### PR TITLE
Add Artisan Facade Import to editMailConfigurationController

### DIFF
--- a/app/Http/App/Controllers/Settings/MailConfiguration/EditMailConfigurationController.php
+++ b/app/Http/App/Controllers/Settings/MailConfiguration/EditMailConfigurationController.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\App\Controllers\Settings\MailConfiguration;
 
-use App\Http\App\Requests\UpdateMailConfigurationRequest;
 use App\Support\ConfigCache;
+use Illuminate\Support\Facades\Artisan;
 use App\Support\MailConfiguration\MailConfiguration;
+use App\Http\App\Requests\UpdateMailConfigurationRequest;
 
 class EditMailConfigurationController
 {


### PR DESCRIPTION
I get Errors in my Horizon Jobs, when I save my Mail Configurations due to a missing Artisan Facade import. This PR adds the Artisan Facade import to the EditMailConfigurationController.
