### PR TITLE
Change default Horizon config to better manage feedback

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -72,17 +72,17 @@ return [
 
     'environments' => [
         'production' => [
-            'supervisor-1' => [
+            'mailcoach-general' => [
                 'connection' => 'redis',
-                'queue' => ['default'],
-                'balance' => 'simple',
+                'queue' => ['default', 'mailcoach', 'mailcoach-feedback'],
+                'balance' => 'auto',
                 'processes' => 10,
                 'tries' => 2,
                 'timeout' => 60 * 60,
             ],
-            'mailcoach' => [
+            'mailcoach-heavy' => [
                 'connection' => 'mailcoach-redis',
-                'queue' => ['send-campaign', 'send-mail', 'mailcoach-feedback', 'mailcoach'],
+                'queue' => ['send-campaign', 'send-mail'],
                 'balance' => 'auto',
                 'processes' => 3,
                 'tries' => 1,
@@ -91,17 +91,17 @@ return [
         ],
 
         'local' => [
-            'supervisor-1' => [
+            'mailcoach-general' => [
                 'connection' => 'redis',
-                'queue' => ['default'],
-                'balance' => 'simple',
+                'queue' => ['default', 'mailcoach', 'mailcoach-feedback'],
+                'balance' => 'auto',
                 'processes' => 10,
                 'tries' => 2,
                 'timeout' => 60 * 60,
             ],
-            'mailcoach' => [
+            'mailcoach-heavy' => [
                 'connection' => 'mailcoach-redis',
-                'queue' => ['send-campaign', 'send-mail', 'mailcoach-feedback', 'mailcoach'],
+                'queue' => ['send-campaign', 'send-mail'],
                 'balance' => 'auto',
                 'processes' => 3,
                 'tries' => 1,

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -74,7 +74,7 @@ return [
         'production' => [
             'mailcoach-general' => [
                 'connection' => 'redis',
-                'queue' => ['default', 'mailcoach', 'mailcoach-feedback'],
+                'queue' => ['default', 'mailcoach', 'mailcoach-feedback', 'send-mail'],
                 'balance' => 'auto',
                 'processes' => 10,
                 'tries' => 2,
@@ -82,7 +82,7 @@ return [
             ],
             'mailcoach-heavy' => [
                 'connection' => 'mailcoach-redis',
-                'queue' => ['send-campaign', 'send-mail'],
+                'queue' => ['send-campaign'],
                 'balance' => 'auto',
                 'processes' => 3,
                 'tries' => 1,
@@ -93,7 +93,7 @@ return [
         'local' => [
             'mailcoach-general' => [
                 'connection' => 'redis',
-                'queue' => ['default', 'mailcoach', 'mailcoach-feedback'],
+                'queue' => ['default', 'mailcoach', 'mailcoach-feedback', 'send-mail'],
                 'balance' => 'auto',
                 'processes' => 10,
                 'tries' => 2,
@@ -101,7 +101,7 @@ return [
             ],
             'mailcoach-heavy' => [
                 'connection' => 'mailcoach-redis',
-                'queue' => ['send-campaign', 'send-mail'],
+                'queue' => ['send-campaign'],
                 'balance' => 'auto',
                 'processes' => 3,
                 'tries' => 1,


### PR DESCRIPTION
The only long running job is `SendCampaignJob` on the `send-campaign` queue. This queue will be handled on a separate Horizon supervisor that has a longer timeout (11 minutes) called `mailcoach-heavy`. All other jobs will be handled on the `mailcoach-general` supervisor that'll automatically assign up to 10 processes to short running jobs.

Real life example; sending a campaign to 50K users: 
- `SendCampaignJob` will lock up `mailcoach-heavy` supervisor for up to 11 minutes
- In the meantime `mailcoach-general` will deal with sending individual mails and processing feedback

### Todo

- [ ] test