### PR TITLE
Add translations

### DIFF
--- a/app/Http/App/Controllers/Settings/Account/AccountController.php
+++ b/app/Http/App/Controllers/Settings/Account/AccountController.php
@@ -20,7 +20,7 @@ class AccountController
             'name' => $request->name,
         ]);
 
-        flash()->success('Your account has been updated.');
+        flash()->success(__('Your account has been updated.'));
 
         return redirect()->action([static::class, 'index']);
     }

--- a/app/Http/App/Controllers/Settings/Account/PasswordController.php
+++ b/app/Http/App/Controllers/Settings/Account/PasswordController.php
@@ -15,7 +15,7 @@ class PasswordController
     {
         auth()->user()->update(['password' => bcrypt($request->password)]);
 
-        flash()->success('Your password has been updated.');
+        flash()->success(__('Your password has been updated.'));
 
         return redirect()->action([static::class, 'index']);
     }

--- a/app/Http/App/Controllers/Settings/App/EditAppConfigurationController.php
+++ b/app/Http/App/Controllers/Settings/App/EditAppConfigurationController.php
@@ -24,7 +24,7 @@ class EditAppConfigurationController
             Artisan::call('horizon:terminate');
         });
 
-        flash()->success('The app configuration was saved.');
+        flash()->success(__('The app configuration was saved.'));
 
         return back();
     }

--- a/app/Http/App/Controllers/Settings/EditorController.php
+++ b/app/Http/App/Controllers/Settings/EditorController.php
@@ -18,7 +18,7 @@ class EditorController
     {
         $editorConfiguration->put($request->validated());
 
-        flash()->success('The editor has been updated.');
+        flash()->success(__('The editor has been updated.'));
 
         ConfigCache::clear();
 

--- a/app/Http/App/Controllers/Settings/MailConfiguration/EditMailConfigurationController.php
+++ b/app/Http/App/Controllers/Settings/MailConfiguration/EditMailConfigurationController.php
@@ -24,7 +24,7 @@ class EditMailConfigurationController
             Artisan::call('horizon:terminate');
         });
 
-        flash()->success('The mail configuration was saved.');
+        flash()->success(__('The mail configuration was saved.'));
 
         return back();
     }

--- a/app/Http/App/Controllers/Settings/MailConfiguration/SendTestMailController.php
+++ b/app/Http/App/Controllers/Settings/MailConfiguration/SendTestMailController.php
@@ -23,11 +23,11 @@ class SendTestMailController
         try {
             Mail::mailer('mailcoach')->to($request->to_email)->sendNow(new TestMail($request->from_email, $request->to_email));
 
-            flash()->success("A test mail has been sent to {$request->to_email}. Please check if it arrived.");
+            flash()->success(__('A test mail has been sent to :email. Please check if it arrived.', ['email' => $request->to_email]));
         } catch (Exception $exception) {
             report($exception);
 
-            flash()->error("Something went wrong with sending the mail: {$exception->getMessage()}");
+            flash()->error(__('Something went wrong with sending the mail: :errorMessage', ['errorMessage' => $exception->getMessage()]));
         }
 
         return redirect()->back();

--- a/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/DeleteTransactionalMailConfiguration.php
+++ b/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/DeleteTransactionalMailConfiguration.php
@@ -8,7 +8,7 @@ class DeleteTransactionalMailConfiguration
 {
     public function __invoke(TransactionalMailConfiguration $mailConfiguration)
     {
-        flash()->success('The transactional mail configuration has been deleted');
+        flash()->success(__('The transactional mail configuration has been deleted'));
 
         $mailConfiguration->empty();
 

--- a/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/EditTransactionalMailConfigurationController.php
+++ b/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/EditTransactionalMailConfigurationController.php
@@ -25,7 +25,7 @@ class EditTransactionalMailConfigurationController
             Artisan::call('horizon:terminate');
         });
 
-        flash()->success('The transactional mail configuration was saved.');
+        flash()->success(__('The transactional mail configuration was saved.'));
 
         return back();
     }

--- a/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/SendTestTransactionalMailController.php
+++ b/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/SendTestTransactionalMailController.php
@@ -27,11 +27,11 @@ class SendTestTransactionalMailController
         try {
             Mail::mailer('mailcoach-transactional')->to($request->to_email)->sendNow((new TransactionalTestMail($request->from_email, $request->to_email)));
 
-            flash()->success("A test mail has been sent to {$request->to_email}. Please check if it arrived.");
+            flash()->success(__('A test mail has been sent to :email. Please check if it arrived.', ['email' => $request->to_email]));
         } catch (Exception $exception) {
             report($exception);
 
-            flash()->error("Something went wrong with sending the mail: {$exception->getMessage()}");
+            flash()->error(__('Something went wrong with sending the mail: :errorMessage', ['errorMessage' => $exception->getMessage()]));
         }
 
         return redirect()->back();

--- a/app/Http/App/Controllers/Settings/Users/CreateUserController.php
+++ b/app/Http/App/Controllers/Settings/Users/CreateUserController.php
@@ -20,10 +20,10 @@ class CreateUserController
         try {
             $user->sendWelcomeNotification($expiresAt);
 
-            flash()->success("The user has been created. A mail with login instructions has been sent to {$user->email}");
+            flash()->success('The user has been created. A mail with login instructions has been sent to :email', ['email' => $user->email]);
         } catch (Exception $exception) {
             report($exception);
-            flash()->warning("The user has been created. A mail with setup instructions could not be sent.");
+            flash()->warning(__('The user has been created. A mail with setup instructions could not be sent.'));
         }
 
         return redirect()->action(UsersIndexController::class);

--- a/app/Http/App/Controllers/Settings/Users/DestroyUserController.php
+++ b/app/Http/App/Controllers/Settings/Users/DestroyUserController.php
@@ -9,14 +9,14 @@ class DestroyUserController
     public function __invoke(User $user)
     {
         if ($user->id === auth()->user()->id) {
-            flash()->error('You cannot delete yourself!');
+            flash()->error(__('You cannot delete yourself!'));
 
             return redirect()->action(UsersIndexController::class);
         }
 
         $user->delete();
 
-        flash()->success('The user has been deleted.');
+        flash()->success(__('The user has been deleted.'));
 
         return redirect()->action(UsersIndexController::class);
     }

--- a/app/Http/App/Controllers/Settings/Users/UpdateUserController.php
+++ b/app/Http/App/Controllers/Settings/Users/UpdateUserController.php
@@ -18,7 +18,7 @@ class UpdateUserController
     {
         $user->update($updateUserRequest->validated());
 
-        flash()->success('The user has been updated.');
+        flash()->success(__('The user has been updated.'));
 
         return redirect()->action(UsersIndexController::class);
     }

--- a/app/Http/App/Requests/UpdateUserRequest.php
+++ b/app/Http/App/Requests/UpdateUserRequest.php
@@ -27,7 +27,7 @@ class UpdateUserRequest extends FormRequest
     public function messages()
     {
         return [
-            'email.unique' => 'There already is a user with this email.',
+            'email.unique' => __('There already is a user with this email.'),
         ];
     }
 

--- a/app/Http/Auth/Controllers/LoginController.php
+++ b/app/Http/Auth/Controllers/LoginController.php
@@ -21,7 +21,7 @@ class LoginController
 
     public function authenticated(Request $request, $user)
     {
-        flash()->success('You are now logged in!');
+        flash()->success(__('You are now logged in!'));
 
         return redirect()->intended(route('mailcoach.campaigns'));
     }

--- a/app/Http/Auth/Controllers/LogoutController.php
+++ b/app/Http/Auth/Controllers/LogoutController.php
@@ -15,7 +15,7 @@ class LogoutController extends LoginController
 
         session()->flush();
 
-        flash()->success('You have been logged out.');
+        flash()->success(__('You have been logged out.'));
 
         return redirect()->action([LoginController::class, 'showLoginForm']);
     }

--- a/app/Http/Auth/Controllers/WelcomeController.php
+++ b/app/Http/Auth/Controllers/WelcomeController.php
@@ -9,7 +9,7 @@ class WelcomeController extends BaseWelcomeController
 {
     public function sendPasswordSavedResponse(): Response
     {
-        flash()->success('Your password has been saved.');
+        flash()->success(__('Your password has been saved.'));
 
         return redirect()->route('mailcoach.campaigns');
     }

--- a/app/Mail/TestMail.php
+++ b/app/Mail/TestMail.php
@@ -25,7 +25,7 @@ class TestMail extends Mailable
     {
         return $this
             ->mailer('mailcoach')
-            ->subject('Mailcoach testmail')
+            ->subject(__('Mailcoach testmail'))
             ->to($this->toEmail)
             ->from($this->fromEmail)
             ->markdown('mails.test');

--- a/app/Mail/TransactionalTestMail.php
+++ b/app/Mail/TransactionalTestMail.php
@@ -24,7 +24,7 @@ class TransactionalTestMail extends Mailable
     public function build()
     {
         return $this
-            ->subject('Mailcoach transactional testmail')
+            ->subject(__('Mailcoach transactional testmail'))
             ->to($this->toEmail)
             ->from($this->fromEmail)
             ->markdown('mails.test');

--- a/resources/lang/vendor/email-campaigns/en/messages.php
+++ b/resources/lang/vendor/email-campaigns/en/messages.php
@@ -1,5 +1,0 @@
-<?php
-
-return [
-    'email_list_email' => 'You are already subscribed.',
-];

--- a/resources/views/app/layouts/partials/health.blade.php
+++ b/resources/views/app/layouts/partials/health.blade.php
@@ -5,8 +5,9 @@
                 @if(! $mailConfigurationValid)
                     <div class="flex items-baseline">
                         <span class="w-6"><i class="fas fa-server opacity-50"></i></span>
-                        <span class="ml-2 text-sm | lg:text-base">Your <strong>mail configuration</strong> is invalid. Head over to the <a href="{{ route('mailConfiguration') }}">mail
-                            configuration</a> screen.</span>
+                        <span class="ml-2 text-sm | lg:text-base">
+                            {!! __('Your <strong>mail configuration</strong> is invalid. Head over to the <a href=":mailConfigurationLink">mail configuration</a> screen.', ['mailConfigurationLink' => route('mailConfiguration')]) !!}
+                        </span>
                     </div>
                 @endif
             @endif
@@ -14,7 +15,9 @@
             @if(! $horizonActive)
                 <div class="flex items-baseline">
                     <span class="w-6"><i class="fas fa-database opacity-50"></i></span>
-                    <span class="ml-2 text-sm | lg:text-base"><strong>Horizon</strong> is not active on your server. <a target="_blank" href="https://mailcoach.app/docs">Read the docs</a>.</span>
+                    <span class="ml-2 text-sm | lg:text-base">
+                        {!! __('<strong>Horizon</strong> is not active on your server. <a target="_blank" href=":docsLink">Read the docs</a>.', ['docsLink' => 'https://mailcoach.app/docs']) !!}
+                    </span>
                 </div>
             @endif
         </div>

--- a/resources/views/app/settings/account/index.blade.php
+++ b/resources/views/app/settings/account/index.blade.php
@@ -1,7 +1,7 @@
 @extends('app.settings.account.layouts.account')
 
 @section('breadcrumbs')
-    <li>Account</li>
+    <li>{{ __('Account') }}</li>
 @endsection
 
 @section('account')
@@ -13,12 +13,12 @@
         @csrf
         @method('PUT')
 
-        <x-text-field label="Email" name="email" type="email" :value="$user->email" required />
-        <x-text-field label="Name" name="name" :value="$user->name" required />
+        <x-text-field :label="__('Email')" name="email" type="email" :value="$user->email" required />
+        <x-text-field :label="__('Name')" name="name" :value="$user->name" required />
 
         <div class="form-buttons">
             <button type="submit" class="button">
-                <x-icon-label icon="fa-user" text="Save user" />
+                <x-icon-label icon="fa-user" :text="__('Save user')" />
             </button>
         </div>
     </form>

--- a/resources/views/app/settings/account/layouts/account.blade.php
+++ b/resources/views/app/settings/account/layouts/account.blade.php
@@ -1,5 +1,5 @@
 @extends('mailcoach::app.layouts.app', [
-    'title' => isset($titlePrefix) ?  $titlePrefix . ' | Account' : 'Account'
+    'title' => isset($titlePrefix) ?  $titlePrefix . ' | ' . __('Account') : __('Account')
 ])
 
 @section('header')
@@ -14,10 +14,10 @@
     <nav class="tabs">
         <ul>
             <x-navigation-item :href="route('account')">
-                <x-icon-label icon="fa-user" text="User details" />
+                <x-icon-label icon="fa-user" :text="__('User details')" />
             </x-navigation-item>
             <x-navigation-item :href="route('password')">
-                <x-icon-label icon="fa-lock" text="Password" />
+                <x-icon-label icon="fa-lock" :text="__('Password')" />
             </x-navigation-item>
         </ul>
     </nav>

--- a/resources/views/app/settings/account/password.blade.php
+++ b/resources/views/app/settings/account/password.blade.php
@@ -1,12 +1,12 @@
-@extends('app.settings.account.layouts.account', ['titlePrefix' => 'Password'])
+@extends('app.settings.account.layouts.account', ['titlePrefix' => __('Password')])
 
 @section('breadcrumbs')
     <li>
         <a href="{{ route('account') }}">
-            Account
+            {{ __('Account') }}
         </a>
     </li>
-    <li>Password</li>
+    <li>{{ __('Password') }}</li>
 @endsection
 
 @section('account')
@@ -18,14 +18,13 @@
         @csrf
         @method('PUT')
 
-        <x-text-field label="Current password" name="current_password" type="password"  required />
-
-        <x-text-field label="New password" name="password" type="password"  required />
-        <x-text-field label="Confirm new password" name="password_confirmation" type="password" required />
+        <x-text-field :label="__('Current password')" name="current_password" type="password"  required />
+        <x-text-field :label="__('New password')" name="password" type="password"  required />
+        <x-text-field :label="__('Confirm new password')" name="password_confirmation" type="password" required />
 
         <div class="form-buttons">
             <button type="submit" class="button">
-                <x-icon-label icon="fa-lock" text="Update password" />
+                <x-icon-label icon="fa-lock" :text="__('Update password')" />
             </button>
         </div>
     </form>

--- a/resources/views/app/settings/appConfiguration/edit.blade.php
+++ b/resources/views/app/settings/appConfiguration/edit.blade.php
@@ -1,10 +1,10 @@
 @extends('mailcoach::app.layouts.app', [
-    'title' => 'App configuration'
+    'title' => __('App configuration')
 ])
 @section('header')
     <nav>
         <ul class="breadcrumbs">
-            <li>App</li>
+            <li>{{ __('App') }}</li>
         </ul>
     </nav>
 @endsection
@@ -20,12 +20,12 @@
             @method('PUT')
             @csrf
 
-            <x-text-field name="name" id="name" label="App name" :value="$appConfiguration->name ?? config('app.name')" />
-            <x-text-field name="url" id="url" label="App url" :value="$appConfiguration->url ?? config('app.url')" />
+            <x-text-field name="name" id="name" :label="__('App name')" :value="$appConfiguration->name ?? config('app.name')" />
+            <x-text-field name="url" id="url" :label="__('App url')" :value="$appConfiguration->url ?? config('app.url')" />
 
             <div class="form-buttons">
                 <button class="button">
-                    <x-icon-label icon="fa-code" text="Save"/>
+                    <x-icon-label icon="fa-code" :text="__('Save')"/>
                 </button>
             </div>
         </form>

--- a/resources/views/app/settings/editor/edit.blade.php
+++ b/resources/views/app/settings/editor/edit.blade.php
@@ -1,10 +1,10 @@
 @extends('mailcoach::app.layouts.app', [
-    'title' => 'Editor configuration'
+    'title' => __('Editor configuration')
 ])
 @section('header')
     <nav>
         <ul class="breadcrumbs">
-            <li>Editor</li>
+            <li>{{ __('Editor') }}</li>
         </ul>
     </nav>
 @endsection
@@ -20,7 +20,7 @@
             @csrf
 
             <x-select-field
-                label="Editor"
+                :label="__('Editor')"
                 name="editor"
                 :value="$editorConfiguration->editor"
                 :options="$editorConfiguration->getAvailableEditors()"
@@ -41,7 +41,7 @@
 
             <div class="form-buttons">
                 <button class="button">
-                    <x-icon-label icon="fa-code" text="Save"/>
+                    <x-icon-label icon="fa-code" :text="__('Save')"/>
                 </button>
             </div>
         </form>

--- a/resources/views/app/settings/editor/partials/monaco.blade.php
+++ b/resources/views/app/settings/editor/partials/monaco.blade.php
@@ -1,37 +1,36 @@
 <x-help>
-    <a href="https://microsoft.github.io/monaco-editor/">Monaco</a> is a powerful code editor created by Microsoft. It
-    provides code highlighting, auto completion and much more.
+    {!! __('<a href=":link">Monaco</a> is a powerful code editor created by Microsoft. It provides code highlighting, auto completion and much more.', ['link' => 'https://microsoft.github.io/monaco-editor/']) !!}
 </x-help>
 
 <x-select-field
-    label="Editor"
+    :label="__('Editor')"
     name="monaco_theme"
     :value="$editorConfiguration->monaco_theme"
     :options="['vs-light' => 'vs-light', 'vs-dark' => 'vs-dark']"
 />
 
 <x-text-field
-    label="Font family"
+    :label="__('Font family')"
     name="monaco_font_family"
     :value="$editorConfiguration->monaco_font_family ?? 'Courier New, Courier, monospace'"
 />
 
 <x-text-field
-    label="Font size"
+    :label="__('Font size')"
     name="monaco_font_size"
     :value="$editorConfiguration->monaco_font_size ?? 16"
     type="number"
 />
 
 <x-text-field
-    label="Font weight"
+    :label="__('Font weight')"
     name="monaco_font_weight"
     :value="$editorConfiguration->monaco_font_weight ?? 400"
     type="number"
 />
 
 <x-text-field
-    label="Line height"
+    :label="__('Line height')"
     name="monaco_line_height"
     :value="$editorConfiguration->monaco_line_height ?? 18"
     type="number"

--- a/resources/views/app/settings/editor/partials/textarea.blade.php
+++ b/resources/views/app/settings/editor/partials/textarea.blade.php
@@ -1,3 +1,3 @@
 <x-help>
-This editor is a plain textarea field.
+{{ __('This editor is a plain textarea field.') }}
 </x-help>

--- a/resources/views/app/settings/editor/partials/unlayer.blade.php
+++ b/resources/views/app/settings/editor/partials/unlayer.blade.php
@@ -1,12 +1,11 @@
 <div>
     <x-help>
-        <a href="https://unlayer.com">Unlayer</a> is a beautiful editor that allows you to edit html in a structured way.
-        You don't need any HTML knowledge to compose a campaign or template. This editor also allows image uploads.
-        <br>Mailcoach uses the free version of Unlayer.
+        {!! __('<a href=":link">Unlayer</a> is a beautiful editor that allows you to edit html in a structured way. You don\'t need any HTML knowledge to compose a campaign or template. This editor also allows image uploads.', ['link' => 'https://unlayer.com']) !!}
+        <br>
+        {{ __('Mailcoach uses the free version of Unlayer.') }}
     </x-help>
 
     <div class="alert alert-warning max-w-xl text-sm">
-        Unlayer editor stores content in a structured way. When switching from or to Unlayer, content in existing
-        templates and draft campaigns will get lost.
+        {{ __('Unlayer editor stores content in a structured way. When switching from or to Unlayer, content in existing templates and draft campaigns will get lost.') }}
     </div>
 </div>

--- a/resources/views/app/settings/mailConfiguration/edit.blade.php
+++ b/resources/views/app/settings/mailConfiguration/edit.blade.php
@@ -1,7 +1,7 @@
-@extends('app.settings.mailConfiguration.layouts.mailConfiguration', ['title' => 'Mail configuration'])
+@extends('app.settings.mailConfiguration.layouts.mailConfiguration', ['title' => __('Mail configuration')])
 
 @section('breadcrumbs')
-    <li>Mail configuration</li>
+    <li>{{ __('Mail configuration') }}</li>
 @endsection
 
 @section('mailConfiguration')
@@ -15,7 +15,7 @@
         @method('PUT')
 
         <x-select-field
-            label="Driver"
+            :label="__('Driver')"
             name="driver"
             :value="$mailConfiguration->driver"
             :options="[
@@ -48,11 +48,11 @@
             @include('app.settings.mailConfiguration.partials.smtp')
         </div>
 
-        <x-text-field label="Default from mail" name="default_from_mail" type="text" :value="$mailConfiguration->default_from_mail"/>
+        <x-text-field :label="__('Default from mail')" name="default_from_mail" type="text" :value="$mailConfiguration->default_from_mail"/>
 
         <div class="form-buttons">
             <button class="button">
-                <x-icon-label icon="fa-server" text="Save configuration" />
+                <x-icon-label icon="fa-server" :text="__('Save configuration')" />
             </button>
         </div>
     </form>

--- a/resources/views/app/settings/mailConfiguration/layouts/mailConfiguration.blade.php
+++ b/resources/views/app/settings/mailConfiguration/layouts/mailConfiguration.blade.php
@@ -1,5 +1,5 @@
 @extends('mailcoach::app.layouts.app', [
-    'title' => isset($titlePrefix) ?  $titlePrefix . ' | Mail configuration' : 'Mail configuration'
+    'title' => isset($titlePrefix) ?  $titlePrefix . ' | ' . __('Mail configuration') : __('Mail configuration')
 ])
 
 @section('header')
@@ -14,10 +14,10 @@
     <nav class="tabs">
         <ul>
             <x-navigation-item :href="route('mailConfiguration')">
-                <x-icon-label icon="fa-server" text="Mail configuration" />
+                <x-icon-label icon="fa-server" :text="__('Mail configuration')" />
             </x-navigation-item>
             <x-navigation-item :href="route('sendTestMail')">
-                <x-icon-label icon="fa-paper-plane" text="Send test mail" />
+                <x-icon-label icon="fa-paper-plane" :text="__('Send test mail')" />
             </x-navigation-item>
         </ul>
     </nav>

--- a/resources/views/app/settings/mailConfiguration/partials/mailgun.blade.php
+++ b/resources/views/app/settings/mailConfiguration/partials/mailgun.blade.php
@@ -1,42 +1,42 @@
 <x-help>
-    Learn how to configure Mailgun by reading <a target="_blank" href="https://mailcoach.app/docs/v2/app/mail-configuration/mailgun">this section of the Mailcoach
-        docs</a>.
+    {!! __('Learn how to configure :provider by reading <a target="_blank" href=":docsLink">this section of the Mailcoach docs</a>.', ['provider' => 'Mailgun', 'docsLink' => 'https://mailcoach.app/docs/v2/app/mail-configuration/mailgun']) !!}
+
     <br>
-    You must set a webhook to
-    <code class="markup-code">{{ url(action(\Spatie\MailcoachMailgunFeedback\MailgunWebhookController::class)) }}</code>
+
+    {!! __('You must set a webhook to: <code class="markup-code">:webhookUrl</code>', ['webhookUrl' => url(action(\Spatie\MailcoachMailgunFeedback\MailgunWebhookController::class))]) !!}
 </x-help>
 
 
 <x-text-field
-    label="Mails per second"
+    :label="__('Mails per second')"
     name="mailgun_mails_per_second"
     type="number"
     :value="$mailConfiguration->mailgun_mails_per_second"
 />
 
 <x-text-field
-    label="Domain"
+    :label="__('Domain')"
     name="mailgun_domain"
     type="text"
     :value="$mailConfiguration->mailgun_domain"
 />
 
 <x-text-field
-    label="Secret"
+    :label="__('Secret')"
     name="mailgun_secret"
     type="password"
     :value="$mailConfiguration->mailgun_secret"
 />
 
 <x-text-field
-    label="Endpoint"
+    :label="__('Endpoint')"
     name="mailgun_endpoint"
     type="text"
     :value="$mailConfiguration->mailgun_endpoint"
 />
 
 <x-text-field
-    label="Webhook signing secret"
+    :label="__('Webhook signing secret')"
     name="mailgun_signing_secret"
     type="secret"
     :value="$mailConfiguration->mailgun_signing_secret"

--- a/resources/views/app/settings/mailConfiguration/partials/postmark.blade.php
+++ b/resources/views/app/settings/mailConfiguration/partials/postmark.blade.php
@@ -1,28 +1,32 @@
 <x-help>
-    Learn how to configure Postmark by reading <a target="_blank" href="https://mailcoach.app/docs/v2/app/mail-configuration/postmark">this section of the Mailcoach
-        docs</a>.
-    <br><br />
-    You must set a webhook to
-    <code class="markup-code">{{ url(action(\Spatie\MailcoachPostmarkFeedback\PostmarkWebhookController::class)) }}</code>. You should set a header <code class="markup-code">mailcoach-signature</code> with the signing secret you specify in the form below.
+    {!! __('Learn how to configure :provider by reading <a target="_blank" href=":docsLink">this section of the Mailcoach docs</a>.', ['provider' => 'Postmark', 'docsLink' => 'https://mailcoach.app/docs/v2/app/mail-configuration/postmark']) !!}
+
+    <br>
+
+    {!! __('You must set a webhook to: <code class="markup-code">:webhookUrl</code>', ['webhookUrl' => url(action(\Spatie\MailcoachPostmarkFeedback\PostmarkWebhookController::class))]) !!}
+
+    <br>
+
+    {!! __('You should set a header <code class="markup-code">:header</code> with the signing secret you specify in the form below.', ['header' => 'mailcoach-signature']) !!}
 </x-help>
 
 
 <x-text-field
-    label="Mails per second"
+    :label="__('Mails per second')"
     name="postmark_mails_per_second"
     type="number"
     :value="$mailConfiguration->postmark_mails_per_second"
 />
 
 <x-text-field
-    label="Server Token"
+    :label="__('Server Token')"
     name="postmark_token"
     type="password"
     :value="$mailConfiguration->postmark_token"
 />
 
 <x-text-field
-    label="Signing secret"
+    :label="__('Signing secret')"
     name="postmark_signing_secret"
     type="password"
     :value="$mailConfiguration->postmark_signing_secret"

--- a/resources/views/app/settings/mailConfiguration/partials/sendgrid.blade.php
+++ b/resources/views/app/settings/mailConfiguration/partials/sendgrid.blade.php
@@ -1,29 +1,27 @@
 <x-help>
-    Learn how to configure Sendgrid by reading <a target="_blank" href="https://mailcoach.app/docs/v2/app/mail-configuration/sendgrid">this section of the
-        Mailcoach docs</a>.
+    {!! __('Learn how to configure :provider by reading <a target="_blank" href=":docsLink">this section of the Mailcoach docs</a>.', ['provider' => 'SendGrid', 'docsLink' => 'https://mailcoach.app/docs/v2/app/mail-configuration/sendgrid']) !!}
+
     <br>
-    You must set a webhook to
-    <code
-        class=markup-code>{{ url(action(\Spatie\MailcoachSendgridFeedback\SendgridWebhookController::class)) . '?secret=' . $mailConfiguration->sendgrid_signing_secret }}</code>
+
+    {!! __('You must set a webhook to: <code class="markup-code">:webhookUrl</code>', ['webhookUrl' => url(action(\Spatie\MailcoachSendgridFeedback\SendgridWebhookController::class)) . '?secret=' . $mailConfiguration->sendgrid_signing_secret ]) !!}
 </x-help>
 
 <x-text-field
-    label="Mails per second"
+    :label="__('Mails per second')"
     name="sendgrid_mails_per_second"
     type="number"
     :value="$mailConfiguration->sendgrid_mails_per_second"
 />
 
 <x-text-field
-    label="API key"
+    :label="__('API key')"
     name="sendgrid_api_key"
     type="password"
     :value="$mailConfiguration->sendgrid_api_key"
 />
 
-
 <x-text-field
-    label="Webhook signing secret"
+    :label="__('Webhook signing secret')"
     name="sendgrid_signing_secret"
     type="text"
     :value="$mailConfiguration->sendgrid_signing_secret"

--- a/resources/views/app/settings/mailConfiguration/partials/ses.blade.php
+++ b/resources/views/app/settings/mailConfiguration/partials/ses.blade.php
@@ -1,42 +1,41 @@
 <x-help>
-    Learn how to configure SES by reading <a target="_blank" href="https://mailcoach.app/docs/v2/app/mail-configuration/amazon-ses">this section of the Mailcoach
-        docs</a>.
+    {!! __('Learn how to configure :provider by reading <a target="_blank" href=":docsLink">this section of the Mailcoach docs</a>.', ['provider' => 'SES', 'docsLink' => 'https://mailcoach.app/docs/v2/app/mail-configuration/amazon-ses']) !!}
+
     <br>
-    You must set a webhook to <code
-        class="markup-code">{{ url(action(\Spatie\MailcoachSesFeedback\SesWebhookController::class)) }}</code>
+
+    {!! __('You must set a webhook to: <code class="markup-code">:webhookUrl</code>', ['webhookUrl' => url(action(\Spatie\MailcoachSesFeedback\SesWebhookController::class))]) !!}
 </x-help>
 
 <x-text-field
-    label="Mails per second"
+    :label="__('Mails per second')"
     name="ses_mails_per_second"
     type="number"
     :value="$mailConfiguration->ses_mails_per_second"
 />
 
 <x-text-field
-    label="Key"
+    :label="__('Key')"
     name="ses_key"
     type="password"
     :value="$mailConfiguration->ses_key"
 />
 
 <x-text-field
-    label="Secret"
+    :label="__('Secret')"
     name="ses_secret"
     type="password"
     :value="$mailConfiguration->ses_secret"
 />
 
 <x-text-field
-    label="Region"
+    :label="__('Region')"
     name="ses_region"
     type="text"
-
     :value="$mailConfiguration->ses_region"
 />
 
 <x-text-field
-    label="Configuration set name"
+    :label="__('Configuration set name')"
     name="ses_configuration_set"
     type="text"
     :value="$mailConfiguration->ses_configuration_set"

--- a/resources/views/app/settings/mailConfiguration/partials/smtp.blade.php
+++ b/resources/views/app/settings/mailConfiguration/partials/smtp.blade.php
@@ -1,5 +1,5 @@
 <x-help>
-    Open and click tracking is not available for the SMTP driver.
+    {{ __('Open and click tracking is not available for the SMTP driver.') }}
 </x-help>
 
 <x-text-field label="Mails per second" name="smtp_mails_per_second" type="number" :value="$mailConfiguration->smtp_mails_per_second"/>

--- a/resources/views/app/settings/mailConfiguration/sendTestMail.blade.php
+++ b/resources/views/app/settings/mailConfiguration/sendTestMail.blade.php
@@ -1,26 +1,26 @@
-@extends('app.settings.mailConfiguration.layouts.mailConfiguration', ['titlePrefix' => 'Send test mail'])
+@extends('app.settings.mailConfiguration.layouts.mailConfiguration', ['titlePrefix' => __('Send test mail')])
 
 @section('breadcrumbs')
     <li>
         <a href="{{ route('mailConfiguration') }}">
-            Mail configuration
+            {{ __('Mail configuration') }}
         </a>
     </li>
-    <li>Send test mail</li>
+    <li>{{ __('Send test mail') }}</li>
 @endsection
 
 @section('mailConfiguration')
     <form class="flex items-end justify-start" method="POST">
         <div class="flex-grow max-w-lg">
-            <x-text-field placeholder="From Email" label="From Email" name="from_email" type="email" :value="auth()->user()->email"/>
+            <x-text-field :placeholder="__('From Email')" :label="__('From Email')" name="from_email" type="email" :value="auth()->user()->email"/>
         </div>
 
         <div class="flex-grow max-w-lg ml-2">
-            <x-text-field placeholder="To Email" label="To Email" name="to_email" type="email"/>
+            <x-text-field :placeholder="__('To Email')" :label="__('To Email')" name="to_email" type="email"/>
         </div>
 
         <button type="submit" class="ml-2 button">
-            <x-icon-label icon="fa-paper-plane" text="Send test mail" />
+            <x-icon-label icon="fa-paper-plane" :text="__('Send test mail')" />
         </button>
     </form>
 @endsection

--- a/resources/views/app/settings/transactionalMailConfiguration/edit.blade.php
+++ b/resources/views/app/settings/transactionalMailConfiguration/edit.blade.php
@@ -1,7 +1,7 @@
-@extends('app.settings.transactionalMailConfiguration.layouts.mailConfiguration', ['title' => 'Transactional mail configuration'])
+@extends('app.settings.transactionalMailConfiguration.layouts.mailConfiguration', ['title' => __('Transactional mail configuration')])
 
 @section('breadcrumbs')
-    <li>Transactional mail configuration</li>
+    <li>{{ __('Transactional mail configuration') }}</li>
 @endsection
 
 @section('mailConfiguration')
@@ -16,13 +16,12 @@
 
         @if(! $mailConfiguration->isValid())
             <div class="alert alert-warning max-w-xl">
-                You haven't configured a transactional mailer yet. Mailcoach will send confirmation mails and welcome mails
-                using the regular mailer.
+                {{ __("You haven't configured a transactional mailer yet. Mailcoach will send confirmation mails and welcome mails using the regular mailer.") }}
             </div>
         @endif
 
         <x-select-field
-            label="Driver"
+            :label="__('Driver')"
             name="driver"
             :value="$mailConfiguration->driver"
             :options="[
@@ -57,7 +56,7 @@
 
         <div class="form-buttons">
             <button class="button">
-                <x-icon-label icon="fa-server" text="Save configuration"/>
+                <x-icon-label icon="fa-server" :text="__('Save configuration')"/>
             </button>
         </div>
     </form>
@@ -73,7 +72,7 @@
             @method('DELETE')
             <div class="form-buttons">
                 <button class="text-red-400 hover:text-red-500">
-                    <x-icon-label caution="true" icon="fa-trash" text="Delete configuration"/>
+                    <x-icon-label caution="true" icon="fa-trash" :text="__('Delete configuration')"/>
                 </button>
             </div>
         </form>

--- a/resources/views/app/settings/transactionalMailConfiguration/layouts/mailConfiguration.blade.php
+++ b/resources/views/app/settings/transactionalMailConfiguration/layouts/mailConfiguration.blade.php
@@ -1,5 +1,5 @@
 @extends('mailcoach::app.layouts.app', [
-    'title' => isset($titlePrefix) ?  $titlePrefix . ' | Transactional mail configuration' : 'Transactional mail configuration'
+    'title' => isset($titlePrefix) ?  $titlePrefix . ' | ' . __('Transactional mail configuration') : __('Transactional mail configuration')
 ])
 
 @section('header')
@@ -14,10 +14,10 @@
     <nav class="tabs">
         <ul>
             <x-navigation-item :href="route('transactionalMailConfiguration')">
-                <x-icon-label icon="fa-server" text="Transactional mail configuration" />
+                <x-icon-label icon="fa-server" :text="__('Transactional mail configuration')" />
             </x-navigation-item>
             <x-navigation-item :href="route('sendTransactionalTestEmail')">
-                <x-icon-label icon="fa-paper-plane" text="Send transactional test mail" />
+                <x-icon-label icon="fa-paper-plane" :text="__('Send transactional test mail')" />
             </x-navigation-item>
         </ul>
     </nav>

--- a/resources/views/app/settings/transactionalMailConfiguration/partials/mailgun.blade.php
+++ b/resources/views/app/settings/transactionalMailConfiguration/partials/mailgun.blade.php
@@ -1,24 +1,23 @@
 <x-help>
-    Learn how to configure Mailgun by reading <a target="_blank" href="https://mailcoach.app/docs/v2/app/mail-configuration/mailgun">this section of the Mailcoach
-        docs</a>.
+    {!! __('Learn how to configure :provider by reading <a target="_blank" href=":docsLink">this section of the Mailcoach docs</a>.', ['provider' => 'Mailgun', 'docsLink' => 'https://mailcoach.app/docs/v2/app/mail-configuration/mailgun']) !!}
 </x-help>
 
 <x-text-field
-    label="Domain"
+    :label="__('Domain')"
     name="mailgun_domain"
     type="text"
     :value="$mailConfiguration->mailgun_domain"
 />
 
 <x-text-field
-    label="Secret"
+    :label="__('Secret')"
     name="mailgun_secret"
     type="password"
     :value="$mailConfiguration->mailgun_secret"
 />
 
 <x-text-field
-    label="Endpoint"
+    :label="__('Endpoint')"
     name="mailgun_endpoint"
     type="text"
     :value="$mailConfiguration->mailgun_endpoint"

--- a/resources/views/app/settings/transactionalMailConfiguration/partials/postmark.blade.php
+++ b/resources/views/app/settings/transactionalMailConfiguration/partials/postmark.blade.php
@@ -1,10 +1,9 @@
 <x-help>
-    Learn how to configure Postmark by reading <a target="_blank" href="https://mailcoach.app/docs/v2/app/mail-configuration/postmark">this section of the Mailcoach
-        docs</a>.
+    {!! __('Learn how to configure :provider by reading <a target="_blank" href=":docsLink">this section of the Mailcoach docs</a>.', ['provider' => 'Postmark', 'docsLink' => 'https://mailcoach.app/docs/v2/app/mail-configuration/postmark']) !!}
 </x-help>
 
 <x-text-field
-    label="Server Token"
+    :label="__('Server Token')"
     name="postmark_token"
     type="password"
     :value="$mailConfiguration->postmark_token"

--- a/resources/views/app/settings/transactionalMailConfiguration/partials/sendgrid.blade.php
+++ b/resources/views/app/settings/transactionalMailConfiguration/partials/sendgrid.blade.php
@@ -1,10 +1,9 @@
 <x-help>
-    Learn how to configure Sendgrid by reading <a target="_blank" href="https://mailcoach.app/docs/v2/app/mail-configuration/sendgrid">this section of the
-        Mailcoach docs</a>.
+    {!! __('Learn how to configure :provider by reading <a target="_blank" href=":docsLink">this section of the Mailcoach docs</a>.', ['provider' => 'SendGrid', 'docsLink' => 'https://mailcoach.app/docs/v2/app/mail-configuration/sendgrid']) !!}
 </x-help>
 
 <x-text-field
-    label="API key"
+    :label="__('API key')"
     name="sendgrid_api_key"
     type="password"
     :value="$mailConfiguration->sendgrid_api_key"

--- a/resources/views/app/settings/transactionalMailConfiguration/partials/ses.blade.php
+++ b/resources/views/app/settings/transactionalMailConfiguration/partials/ses.blade.php
@@ -1,26 +1,24 @@
 <x-help>
-    Learn how to configure SES by reading <a target="_blank" href="https://mailcoach.app/docs/v2/app/mail-configuration/amazon-ses">this section of the Mailcoach
-        docs</a>.
+    {!! __('Learn how to configure :provider by reading <a target="_blank" href=":docsLink">this section of the Mailcoach docs</a>.', ['provider' => 'SES', 'docsLink' => 'https://mailcoach.app/docs/v2/app/mail-configuration/amazon-ses']) !!}
 </x-help>
 
 <x-text-field
-    label="Key"
+    :label="__('Key')"
     name="ses_key"
     type="password"
     :value="$mailConfiguration->ses_key"
 />
 
 <x-text-field
-    label="Secret"
+    :label="__('Secret')"
     name="ses_secret"
     type="password"
     :value="$mailConfiguration->ses_secret"
 />
 
 <x-text-field
-    label="Region"
+    :label="__('Region')"
     name="ses_region"
     type="text"
-
     :value="$mailConfiguration->ses_region"
 />

--- a/resources/views/app/settings/transactionalMailConfiguration/partials/smtp.blade.php
+++ b/resources/views/app/settings/transactionalMailConfiguration/partials/smtp.blade.php
@@ -1,6 +1,4 @@
-<x-text-field label="Host" name="smtp_host" type="text" :value="$mailConfiguration->smtp_host"/>
-<x-text-field label="Port" name="smtp_port" type="number" :value="$mailConfiguration->smtp_port"/>
-<x-text-field label="Username" name="smtp_username" type="text"
-                :value="$mailConfiguration->smtp_username"/>
-<x-text-field label="Password" name="smtp_password" type="password"
-                :value="$mailConfiguration->smtp_password"/>
+<x-text-field :label="__('Host')" name="smtp_host" type="text" :value="$mailConfiguration->smtp_host"/>
+<x-text-field :label="__('Port')" name="smtp_port" type="number" :value="$mailConfiguration->smtp_port"/>
+<x-text-field :label="__('Username')" name="smtp_username" type="text" :value="$mailConfiguration->smtp_username"/>
+<x-text-field :label="__('Password')" name="smtp_password" type="password" :value="$mailConfiguration->smtp_password"/>

--- a/resources/views/app/settings/transactionalMailConfiguration/sendTestMail.blade.php
+++ b/resources/views/app/settings/transactionalMailConfiguration/sendTestMail.blade.php
@@ -1,12 +1,12 @@
-@extends('app.settings.transactionalMailConfiguration.layouts.mailConfiguration', ['titlePrefix' => 'Send test mail'])
+@extends('app.settings.transactionalMailConfiguration.layouts.mailConfiguration', ['titlePrefix' => __('Send test mail')])
 
 @section('breadcrumbs')
     <li>
         <a href="{{ route('mailConfiguration') }}">
-            Transactional mail configuration
+            {{ __('Transactional mail configuration') }}
         </a>
     </li>
-    <li>Send test mail</li>
+    <li>{{ __('Send test mail') }}</li>
 @endsection
 
 @section('mailConfiguration')
@@ -14,20 +14,20 @@
 
     <form class="flex items-end justify-start" method="POST">
         <div class="flex-grow max-w-lg">
-            <x-text-field placeholder="From Email" label="From Email" name="from_email" type="email" :value="auth()->user()->email"/>
+            <x-text-field :placeholder="__('From Email')" :label="__('From Email')" name="from_email" type="email" :value="auth()->user()->email"/>
         </div>
 
         <div class="flex-grow max-w-lg ml-2">
-            <x-text-field placeholder="To Email" label="To Email" name="to_email" type="email"/>
+            <x-text-field :placeholder="__('To Email')" :label="__('To Email')" name="to_email" type="email"/>
         </div>
 
         <button type="submit" class="ml-2 button">
-            <x-icon-label icon="fa-paper-plane" text="Send test mail" />
+            <x-icon-label icon="fa-paper-plane" :text="__('Send test mail')" />
         </button>
     </form>
     @else
         <div class="alert alert-warning max-w-xl">
-            You haven't configured a transactional mailer yet.
+            {{ __("You haven't configured a transactional mailer yet.") }}
         </div>
     @endif
 @endsection

--- a/resources/views/app/settings/users/edit.blade.php
+++ b/resources/views/app/settings/users/edit.blade.php
@@ -4,7 +4,7 @@
 <nav>
     <ul class="breadcrumbs">
         <li>
-            <a href="{{ route('users') }}">Users</a>
+            <a href="{{ route('users') }}">{{ __('Users') }}</a>
         </li>
         <li>
             {{ $user->email }}
@@ -20,13 +20,13 @@
         @csrf
         @method('PUT')
 
-        <x-text-field type="email" label="Email" name="email" :value="$user->email" required />
+        <x-text-field type="email" :label="__('Email')" name="email" :value="$user->email" required />
 
-        <x-text-field label="Name" name="name" :value="$user->name" required />
+        <x-text-field :label="__('Name')" name="name" :value="$user->name" required />
 
         <div class="form-buttons">
             <button type="submit" class="button">
-                <x-icon-label icon="fa-user" text="Save user" />
+                <x-icon-label icon="fa-user" :text="__('Save user')" />
             </button>
         </div>
     </form>

--- a/resources/views/app/settings/users/index.blade.php
+++ b/resources/views/app/settings/users/index.blade.php
@@ -1,10 +1,10 @@
-@extends('mailcoach::app.layouts.app', ['title' => 'Users'])
+@extends('mailcoach::app.layouts.app', ['title' => __('Users')])
 
 @section('header')
 <nav class="breadcrumbs">
     <ul>
         <li>
-            Users
+            {{ __('Users') }}
         </li>
     </ul>
 </nav>
@@ -13,24 +13,24 @@
 @section('content')
     <section class="card">
         <div class="table-actions">
-            <button class="button" data-modal-trigger="create-template">
-                <x-icon-label icon="fa-user" text="Create new user" />
+            <button class="button" data-modal-trigger="create-user">
+                <x-icon-label icon="fa-user" :text="__('Create new user')" />
             </button>
 
-            <x-modal title="Create user" name="create-template" :open="$errors->any()">
+            <x-modal title="Create user" name="create-user" :open="$errors->any()">
                 @include('app.settings.users.partials.create')
             </x-modal>
 
             <div class=table-filters>
-                <x-search placeholder="Filter users…" />
+                <x-search :placeholder="__('Filter users…')" />
             </div>
         </div>
 
         <table class="table">
             <thead>
                 <tr>
-                    <x-th sort-by="email" sort-default>Email</x-th>
-                    <x-th sort-by="-name">Name</x-th>
+                    <x-th sort-by="email" sort-default>{{ __('Email') }}</x-th>
+                    <x-th sort-by="-name">{{ __('Name') }}</x-th>
                     <th></th>
                 </tr>
             </thead>
@@ -52,7 +52,7 @@
                             <ul class="dropdown-list dropdown-list-left | hidden" data-dropdown-list>
                                 <li>
                                     <x-form-button :action="route('users.delete', $user)" method="DELETE" data-confirm>
-                                        <x-icon-label icon="fa-trash-alt" text="Delete" :caution="true" />
+                                        <x-icon-label icon="fa-trash-alt" :text="__('Delete')" :caution="true" />
                                     </x-form-button>
                                 </li>
                             </ul>
@@ -64,6 +64,6 @@
             </tbody>
         </table>
 
-        <x-table-status name="user" :paginator="$users" :total-count="$totalUsersCount" :show-all-url="route('users')">
+        <x-table-status :name="__('user|users')" :paginator="$users" :total-count="$totalUsersCount" :show-all-url="route('users')">
         </x-table-status>
 @endsection

--- a/resources/views/app/settings/users/partials/create.blade.php
+++ b/resources/views/app/settings/users/partials/create.blade.php
@@ -1,15 +1,15 @@
 <form class="form-grid" action="{{ route('users.create') }}" method="POST">
     @csrf
-    <x-text-field type="email" label="Email" name="email" required />
+    <x-text-field type="email" :label="__('Email')" name="email" required />
 
-    <x-text-field label="Name" name="name" required />
+    <x-text-field :label="__('Name')" name="name" required />
 
     <div class="form-buttons">
         <button class="button">
-            <x-icon-label icon="fa-user" text="Create new user" />
+            <x-icon-label icon="fa-user" :text="__('Create new user')" />
         </button>
         <button type="button" class="button-cancel" data-modal-dismiss>
-            Cancel
+            {{ __('Cancel') }}
         </button>
     </div>
 </form>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -20,7 +20,7 @@
         </div>
 
         <div class="form-group row">
-            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
+            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('Email Address') }}</label>
 
             <div class="col-md-6">
                 <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email"

--- a/resources/views/mails/test.blade.php
+++ b/resources/views/mails/test.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
 
-Hi,
+{{ __('Hi') }}
 
-this is a test email sent from Mailcoach.
+{{ __('This is a test email sent from Mailcoach.') }}
 
 @endcomponent

--- a/resources/views/mails/transactionalTest.blade.php
+++ b/resources/views/mails/transactionalTest.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
 
-Hi,
+{{ __('Hi') }}
 
-this is a test email sent from Mailcoach using the transactional configuration.
+{{ __('This is a test email sent from Mailcoach using the transactional configuration.') }}
 
 @endcomponent

--- a/resources/views/mails/welcome.blade.php
+++ b/resources/views/mails/welcome.blade.php
@@ -1,16 +1,16 @@
-<h1>Welcome to <a href="{{ config('app.url') }}">{{ config('app.name') }}</a></h1>
+<h1>{!! __('Welcome to <a href=":appLink">:appName</a>', ['appLink' => config('app.link'), 'appName' => config('app.name')]) !!}</h1>
 <p>
-    Dear {{ $user->first_name }},
+    {{ __('Dear :firstName', ['firstName' => $user->first_name]) }},
 </p>
 <p>
-    Your account has been approved. You can now pick a password at our site and login.
+    {{ __('Your account has been approved. You can now pick a password at our site and login.') }}
 </p>
 <table>
     <tr>
         <td>
             <p>
                 <a href="{{ route('welcome', [$user->id, $token]) }}" class="btn-primary">
-                    Pick a password
+                    {{ __('Pick a password') }}
                 </a>
             </p>
         </td>
@@ -18,6 +18,8 @@
 </table>
 
 <p>
-    <em>This link is valid until {{ now()->addMinutes(config('auth.passwords.users.expire'))->format('Y/m/d') }}.</em>
+    <em>
+        {{ __('This link is valid until :validUntil', ['validUntil' => now()->addMinutes(config('auth.passwords.users.expire'))->format('Y/m/d')]) }}
+    </em>
 </p>
 

--- a/resources/views/vendor/mailcoach/app/layouts/partials/headerRight.blade.php
+++ b/resources/views/vendor/mailcoach/app/layouts/partials/headerRight.blade.php
@@ -6,7 +6,7 @@
         <li>
             <a href="{{ route('account') }}">
                 <span class="icon-label">
-                    <i class="fas fa-fw fa-user"></i> Account
+                    <i class="fas fa-fw fa-user"></i> {{ __('Account') }}
                 </span>
             </a>
         </li>
@@ -15,46 +15,46 @@
                 <button type="submit">
                     <span class="icon-label">
                         <i class="fas fa-fw fa-power-off text-red-500"></i>
-                        Log out
+                        {{ __('Log out') }}
                     </span>
                 </button>
             </form>
         </li>
         <li class="my-2 py-2 border-t border-gray-200">
-            <p class="px-4 py-2 uppercase text-xs text-gray-400 tracking-widest"> Configuration</p>
+            <p class="px-4 py-2 uppercase text-xs text-gray-400 tracking-widest"> {{ __('Configuration') }}</p>
             <ul>
                 <li>
                     <a href="{{ route('appConfiguration') }}">
                         <span class="icon-label">
-                            <i class="fas fa-fw fa-cog"></i> App
+                            <i class="fas fa-fw fa-cog"></i> {{ __('App') }}
                         </span>
                     </a>
                 </li>
                 <li>
                     <a href="{{ route('users') }}">
                         <span class="icon-label">
-                            <i class="fas fa-fw fa-users"></i> Users
+                            <i class="fas fa-fw fa-users"></i> {{ __('Users') }}
                         </span>
                     </a>
                 </li>
                 <li>
                     <a href="{{ route('mailConfiguration') }}">
                         <span class="icon-label whitespace-no-wrap">
-                            <i class="fas fa-fw fa-mail-bulk"></i> Mail
+                            <i class="fas fa-fw fa-mail-bulk"></i> {{ __('Mail') }}
                         </span>
                     </a>
                 </li>
                 <li>
                     <a href="{{ route('transactionalMailConfiguration') }}">
                         <span class="icon-label whitespace-no-wrap">
-                            <i class="fas fa-fw fa-handshake"></i> Transactional mail
+                            <i class="fas fa-fw fa-handshake"></i> {{ __('Transactional mail') }}
                         </span>
                     </a>
                 </li>
                 <li>
                     <a href="{{ route('editor') }}">
                         <span class="icon-label whitespace-no-wrap">
-                            <i class="fas fa-fw fa-code"></i> Editor
+                            <i class="fas fa-fw fa-code"></i> {{ __('Editor') }}
                         </span>
                     </a>
                 </li>


### PR DESCRIPTION
Followup of https://github.com/spatie/laravel-mailcoach/pull/247

Only case i didn't know exactly what to do was the `ForgotPasswordController` & `ResetPasswordController`, because this already contains a `trans` call from the Laravel password broker's response. So left that intact.