### PR TITLE
Added missing imports to the mail configuration settings controllers.

### DIFF
--- a/app/Http/App/Controllers/Settings/MailConfiguration/SendTestMailController.php
+++ b/app/Http/App/Controllers/Settings/MailConfiguration/SendTestMailController.php
@@ -5,7 +5,7 @@ namespace App\Http\App\Controllers\Settings\MailConfiguration;
 use App\Mail\TestMail;
 use Exception;
 use Illuminate\Http\Request;
-use Mail;
+use Illuminate\Support\Facades\Mail;
 
 class SendTestMailController
 {

--- a/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/EditTransactionalMailConfigurationController.php
+++ b/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/EditTransactionalMailConfigurationController.php
@@ -5,6 +5,7 @@ namespace App\Http\App\Controllers\Settings\TransactionalMailConfiguration;
 use App\Http\App\Requests\UpdateTransactionalMailConfigurationRequest;
 use App\Support\ConfigCache;
 use App\Support\TransactionalMailConfiguration\TransactionalMailConfiguration;
+use Illuminate\Support\Facades\Artisan;
 
 class EditTransactionalMailConfigurationController
 {

--- a/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/SendTestTransactionalMailController.php
+++ b/app/Http/App/Controllers/Settings/TransactionalMailConfiguration/SendTestTransactionalMailController.php
@@ -6,7 +6,7 @@ use App\Mail\TransactionalTestMail;
 use App\Support\TransactionalMailConfiguration\TransactionalMailConfiguration;
 use Exception;
 use Illuminate\Http\Request;
-use Mail;
+use Illuminate\Support\Facades\Mail;
 
 class SendTestTransactionalMailController
 {


### PR DESCRIPTION
I got an error every time i updated the mail configuration in mailcoach. Turns out the artisan facade was missing.