### PR TITLE
Update Horizon config

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -69,6 +69,8 @@ return [
     | queued jobs and will be provisioned by Horizon during deployment.
     |
     */
+    
+    'defaults' => [],
 
     'environments' => [
         'production' => [


### PR DESCRIPTION
Since this PR https://github.com/laravel/horizon/pull/869 a supervisor called `supervisor-1` will _always_ be created that processes the `default` the queue. This can be overridden, but as Mailcoach doesn't have a supervisor, called `supervisor-1`, a default one is created.

In the Mailcoach Horizon config, the `mailcoach-general` supervisor should processes the default queue, not `supervisor-1`.

It was also a little confusing not knowing why a `supervisor-1` was being created when it hadn't been specified.

Thank