### PR TITLE
feat: Added horizon metrics

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -28,6 +28,8 @@ class Kernel extends ConsoleKernel
         $schedule->command('mailcoach:cleanup-processed-feedback')->hourly();
         $schedule->command('mailcoach:send-email-list-summary-mail')->mondays()->at('9:00');
         $schedule->command('mailcoach:delete-old-unconfirmed-subscribers')->daily();
+        
+        $schedule->command('horizon:snapshot')->everyFiveMinutes();
     }
 
     /**


### PR DESCRIPTION
Hi!
I think if Mailcoach ships with Horizon by default, it should also include metrics by default so that we can make use of `/horizon` dashboard.

Have a good day!