### PR TITLE
fix: WelcomesNewUsers

### DIFF
--- a/app/Http/Middleware/WelcomesNewUsers.php
+++ b/app/Http/Middleware/WelcomesNewUsers.php
@@ -14,15 +14,15 @@ class WelcomesNewUsers
             abort(Response::HTTP_FORBIDDEN, __mc('The welcome link does not have a valid signature or is expired.'));
         }
 
-        if (! $request->mailcoachUser) {
+        if (! $request->user) {
             abort(Response::HTTP_FORBIDDEN, __mc('Could not find a user to be welcomed.'));
         }
 
-        if (is_null($request->mailcoachUser->welcome_valid_until)) {
+        if (is_null($request->user->welcome_valid_until)) {
             abort(Response::HTTP_FORBIDDEN, __mc('The welcome link has already been used.'));
         }
 
-        if (Carbon::create($request->mailcoachUser->welcome_valid_until)->isPast()) {
+        if (Carbon::create($request->user->welcome_valid_until)->isPast()) {
             abort(Response::HTTP_FORBIDDEN, __mc('The welcome link has expired.'));
         }
 


### PR DESCRIPTION
In current setup, new users cannot set their password because variable name from web.php doesn't match with WelcomesNewUsers:
<img width="426" alt="image" src="https://github.com/spatie/Mailcoach/assets/5730766/434dc3c4-a7dd-4f91-af11-f65a19184593">
This PR fixes that by renaming mailcoachUser variable to user inside WelcomesNewUsers.