### PR TITLE
Update .gitignore.example for horizon mix-manifest

### DIFF
--- a/.gitignore.example
+++ b/.gitignore.example
@@ -26,5 +26,5 @@ coverage
 .php_cs.cache
 .php-cs-fixer.cache
 node_modules
-mix-manifest.json
+/mix-manifest.json
 dump.rdb


### PR DESCRIPTION
An error occurred when visiting `/horizon` and the `public_path('vendor/horizon/mix-manifest.json')` isn't published (error: `Horizon assets are not published. Please run: php artisan horizon:publish`).