### PR TITLE
fix: route name for password reset

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ Route::post('login', [LoginController::class, 'login']);
 Route::get('forgot-password', [ForgotPasswordController::class, 'showLinkRequestForm'])->name('forgot-password');
 Route::post('forgot-password', [ForgotPasswordController::class, 'sendResetLinkEmail'])->name('password.email');
 
-Route::get('reset-password', [ResetPasswordController::class, 'showResetForm'])->name('password.reset');
+Route::get('reset-password', [ResetPasswordController::class, 'showResetForm'])->name('mailcoach.password.reset');
 Route::post('reset-password', [ResetPasswordController::class, 'reset'])->name('password.update');
 
 Route::middleware('web', WelcomesNewUsers::class)->group(function () {


### PR DESCRIPTION
This:
https://github.com/ImJustToNy/Mailcoach/blob/3d3cf7a80ee60e37e834de0065738217b634a9bb/routes/web.php#L25

should match this:
https://github.com/spatie/laravel-mailcoach/blob/ab5eac0398fe3663915a1c366934f8cb043ead83/src/Http/App/Middleware/BootstrapMailcoach.php#L30