### PR TITLE
Fix array structure in return type docblock in MakeUserCommand.php

### DIFF
--- a/app/Console/Commands/MakeUserCommand.php
+++ b/app/Console/Commands/MakeUserCommand.php
@@ -23,7 +23,7 @@ class MakeUserCommand extends Command
         return self::SUCCESS;
     }
 
-    /** @return array{'username': string, 'email': string, 'password': string} */
+    /** @return array{'name': string, 'email': string, 'password': string} */
     protected function requestData(): array
     {
         return [


### PR DESCRIPTION
Hi,

I noticed when installing Larastan in a self hosted version of mailcoach that the array structure of the requestData() method in the MakeUserCommand was incorrect, it lists `username` as an array key, but the actual key returned is simply `name`

Thanks as always for the great work :) 