### PR TITLE
Queue welcome notification and add resend invitation button

### DIFF
--- a/app/Livewire/CreateUserComponent.php
+++ b/app/Livewire/CreateUserComponent.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use App\Models\User;
+use App\Notifications\QueuedWelcomeNotification;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
@@ -12,7 +13,6 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Livewire\Component;
-use Spatie\WelcomeNotification\WelcomeNotification;
 
 class CreateUserComponent extends Component implements HasActions, HasForms
 {
@@ -37,15 +37,9 @@ class CreateUserComponent extends Component implements HasActions, HasForms
         $user->password = Hash::make(Str::random(64));
         $user->save();
 
-        try {
-            $user->sendWelcomeNotification(now()->addDay());
+        $user->notify(new QueuedWelcomeNotification(now()->addDay()));
 
-            notify(__mc('The user has been created. A mail with login instructions has been sent to :email', ['email' => $user->email]));
-
-        } catch (\Throwable $e) {
-            report($e);
-            notifyError(__mc('The user has been created. A mail with setup instructions could not be sent: '.$e->getMessage()));
-        }
+        notify(__mc('The user has been created. A mail with login instructions will be sent to :email', ['email' => $user->email]));
 
         return redirect()->route('users.edit', $user);
     }

--- a/app/Livewire/EditUserComponent.php
+++ b/app/Livewire/EditUserComponent.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use App\Models\User;
+use App\Notifications\QueuedWelcomeNotification;
 use Illuminate\Validation\Rule;
 use Livewire\Component;
 
@@ -35,6 +36,13 @@ class EditUserComponent extends Component
         $this->user->save();
 
         notify(__mc('The user has been updated.'));
+    }
+
+    public function resendInvitation(): void
+    {
+        $this->user->notify(new QueuedWelcomeNotification(now()->addDay()));
+
+        notify(__mc('An invitation mail will be sent to :email.', ['email' => $this->user->email]));
     }
 
     public function render()

--- a/app/Notifications/QueuedWelcomeNotification.php
+++ b/app/Notifications/QueuedWelcomeNotification.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Spatie\WelcomeNotification\WelcomeNotification;
+
+class QueuedWelcomeNotification extends WelcomeNotification implements ShouldQueue
+{
+    use Queueable;
+}

--- a/resources/views/livewire/users/edit.blade.php
+++ b/resources/views/livewire/users/edit.blade.php
@@ -15,6 +15,11 @@
 
         <x-mailcoach::form-buttons>
             <x-mailcoach::button :label="__mc('Save user')" />
+            @if($user->welcome_valid_until)
+                <button type="button" wire:click="resendInvitation" class="button-secondary">
+                    {{ __mc('Resend invitation mail') }}
+                </button>
+            @endif
         </x-mailcoach::form-buttons>
     </x-mailcoach::card>
 </form>


### PR DESCRIPTION
## Summary
- Queue the welcome notification via `ShouldQueue` so user creation is fast and resilient to mail service outages
- Add a "Resend invitation mail" button on the user edit page for users who haven't completed setup yet

Fixes spatie/laravel-mailcoach#1919

## Test plan
- [ ] Create a new user and verify the welcome email is dispatched to the queue instead of being sent synchronously
- [ ] Edit a user who hasn't completed setup and verify the "Resend invitation mail" button is visible
- [ ] Click "Resend invitation mail" and verify a new queued notification is dispatched
- [ ] Verify the button is hidden for users who have already set their password

🤖 Generated with [Claude Code](https://claude.com/claude-code)